### PR TITLE
Io 64 configuration properties and keys

### DIFF
--- a/analysis.cli/iobserve.example.properties
+++ b/analysis.cli/iobserve.example.properties
@@ -25,13 +25,22 @@ iobserve.analysis.lqnsUriPath
 
 # unknown
 iobserve.analysis.deployables_folder_path
-
-iobserve.analysis.behavior.visualization.url
-
+iobserve.analysis.container.management.sink.visualizationUrl
 
 ##########
 # behavior
 iobserve.analysis.behaviour.toggle = Place here a composite stage for behavior
+iobserve.analysis.behaviour.filter
+iobserve.analysis.behaviour.sink.visual
+
+#source
+iobserve.analysis.source
+
+#traces
+iobserve.analysis.traces
+
+#dataflow
+iobserve.analysis.dataFlow
 
 # behavior - poepke analysis
 iobserve.analysis.behavior.closed.workload
@@ -43,8 +52,13 @@ iobserve.analysis.model.pcm.directory.db
 iobserve.analysis.model.pcm.directory.init
 
 ############
-# container management
+# container management 
+iobserve.analysis.container.management.analysis = true
 
+#geolocation
+org.iobserve.analysis.IGeoLocationCompositeStage = true
+
+########deprecated
 # deployment
 iobserve.analysis.deployment.toggle = false
 

--- a/analysis/src/main/java/org/iobserve/analysis/configurations/AbstractObservationConfiguration.java
+++ b/analysis/src/main/java/org/iobserve/analysis/configurations/AbstractObservationConfiguration.java
@@ -128,7 +128,7 @@ public abstract class AbstractObservationConfiguration extends Configuration {
 
         /** deployment. */
         if (featureToggle.getDeploymentToggle()) {
-            this.deploymentStage = new DeploymentCompositeStage(configuration, resourceEnvironmentModelProvider,
+            this.deploymentStage = new DeploymentCompositeStage(resourceEnvironmentModelProvider,
                     allocationModelProvider, systemModelProvider, correspondenceModel);
         }
 

--- a/analysis/src/main/java/org/iobserve/analysis/configurations/AnalysisConfiguration.java
+++ b/analysis/src/main/java/org/iobserve/analysis/configurations/AnalysisConfiguration.java
@@ -15,14 +15,6 @@
  ***************************************************************************/
 package org.iobserve.analysis.configurations;
 
-import java.io.File;
-import teetime.framework.Configuration;
-import teetime.framework.OutputPort;
-import teetime.stage.basic.distributor.Distributor;
-import teetime.stage.basic.distributor.strategy.CopyByReferenceStrategy;
-import teetime.stage.basic.distributor.strategy.IDistributorStrategy;
-import teetime.stage.trace.traceReconstruction.EventBasedTrace;
-
 import org.iobserve.analysis.ConfigurationException;
 import org.iobserve.analysis.IBehaviorCompositeStage;
 import org.iobserve.analysis.IContainerManagementSinksStage;
@@ -52,6 +44,7 @@ import teetime.stage.basic.distributor.Distributor;
 import teetime.stage.basic.distributor.strategy.CopyByReferenceStrategy;
 import teetime.stage.basic.distributor.strategy.IDistributorStrategy;
 import teetime.stage.trace.traceReconstruction.EventBasedTrace;
+
 /**
  * This is a generic configuration for all analyses.
  *
@@ -141,7 +134,7 @@ public class AnalysisConfiguration extends Configuration {
             this.connectPorts(this.recordSwitch.getAllocationOutputPort(), this.allocationStage.getInputPort());
 
             /** deployment. */
-            this.deploymentStage = new DeploymentCompositeStage(configuration, resourceEnvironmentModelProvider,
+            this.deploymentStage = new DeploymentCompositeStage(resourceEnvironmentModelProvider,
                     allocationModelProvider, systemModelProvider, correspondenceModelProvider);
             /** connect ports. */
             this.connectPorts(this.recordSwitch.getDeployedOutputPort(), this.deploymentStage.getDeployedInputPort());

--- a/analysis/src/main/java/org/iobserve/analysis/deployment/DeploymentCompositeStage.java
+++ b/analysis/src/main/java/org/iobserve/analysis/deployment/DeploymentCompositeStage.java
@@ -15,12 +15,6 @@
  ***************************************************************************/
 package org.iobserve.analysis.deployment;
 
-import kieker.common.configuration.Configuration;
-
-import teetime.framework.InputPort;
-import teetime.framework.OutputPort;
-
-import org.iobserve.analysis.AbstractConfigurableCompositeStage;
 import org.iobserve.analysis.IDeploymentCompositeStage;
 import org.iobserve.analysis.deployment.data.PCMDeployedEvent;
 import org.iobserve.common.record.IDeployedEvent;
@@ -32,6 +26,10 @@ import org.palladiosimulator.pcm.resourceenvironment.ResourceContainer;
 import org.palladiosimulator.pcm.resourceenvironment.ResourceEnvironment;
 import org.palladiosimulator.pcm.system.System;
 
+import teetime.framework.CompositeStage;
+import teetime.framework.InputPort;
+import teetime.framework.OutputPort;
+
 /**
  * Composite stage for deployment. This stage automatically creates an allocation (in PCM creates a
  * resource container) for the deployment in case the deployment target does not exists.
@@ -39,7 +37,7 @@ import org.palladiosimulator.pcm.system.System;
  * @author Reiner Jung
  *
  */
-public class DeploymentCompositeStage extends AbstractConfigurableCompositeStage implements IDeploymentCompositeStage {
+public class DeploymentCompositeStage extends CompositeStage implements IDeploymentCompositeStage {
 
     private final DeployPCMMapper deployPCMMapper;
     private final AggregateEventStage<PCMDeployedEvent> relayDeployedEventStage;
@@ -59,11 +57,9 @@ public class DeploymentCompositeStage extends AbstractConfigurableCompositeStage
      * @param correspondence
      *            the correspondence model handler
      */
-    public DeploymentCompositeStage(final Configuration configuration,
-            final IModelProvider<ResourceEnvironment> resourceEnvironmentModelProvider,
+    public DeploymentCompositeStage(final IModelProvider<ResourceEnvironment> resourceEnvironmentModelProvider,
             final IModelProvider<Allocation> allocationModelProvider, final IModelProvider<System> systemModelProvider,
             final ICorrespondence correspondence) {
-        super(configuration);
 
         this.deployPCMMapper = new DeployPCMMapper(correspondence);
         final SynthesizeAllocationEventStage synthesizeAllocationEvent = new SynthesizeAllocationEventStage(

--- a/monitoring/build.gradle
+++ b/monitoring/build.gradle
@@ -10,6 +10,8 @@ if (group.isEmpty()) {
 
 dependencies {
 	clover 'org.openclover:clover:4.2.0'
+	
+	compile 'org.slf4j:slf4j-simple:1.7.25'
 
 	compile project(":common")
 	compile 'net.kieker-monitoring:kieker:1.14-SNAPSHOT'

--- a/service.privacy.violation/src/main/java/org/iobserve/service/privacy/violation/PrivacyViolationDetectionConfiguration.java
+++ b/service.privacy.violation/src/main/java/org/iobserve/service/privacy/violation/PrivacyViolationDetectionConfiguration.java
@@ -19,12 +19,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
-import teetime.framework.Configuration;
-import teetime.stage.trace.traceReconstruction.EventBasedTrace;
-import teetime.stage.trace.traceReconstruction.EventBasedTraceFactory;
-import teetime.stage.trace.traceReconstruction.TraceReconstructionFilter;
-import teetime.util.ConcurrentHashMapWithDefault;
-
 import org.iobserve.analysis.deployment.AllocationStage;
 import org.iobserve.analysis.deployment.DeploymentCompositeStage;
 import org.iobserve.analysis.deployment.UndeploymentCompositeStage;
@@ -47,6 +41,12 @@ import org.iobserve.stages.source.MultipleConnectionTcpReaderStage;
 import org.palladiosimulator.pcm.allocation.Allocation;
 import org.palladiosimulator.pcm.resourceenvironment.ResourceEnvironment;
 import org.palladiosimulator.pcm.system.System;
+
+import teetime.framework.Configuration;
+import teetime.stage.trace.traceReconstruction.EventBasedTrace;
+import teetime.stage.trace.traceReconstruction.EventBasedTraceFactory;
+import teetime.stage.trace.traceReconstruction.TraceReconstructionFilter;
+import teetime.util.ConcurrentHashMapWithDefault;
 
 /**
  * Configuration for the log replayer.
@@ -96,8 +96,8 @@ public class PrivacyViolationDetectionConfiguration extends Configuration {
         final AllocationStage allocationStage = new AllocationStage(resourceEnvironmentModelProvider);
 
         /** deployment. */
-        final DeploymentCompositeStage deploymentStage = new DeploymentCompositeStage(configuration,
-                resourceEnvironmentModelProvider, allocationModelProvider, systemModelProvider, rac);
+        final DeploymentCompositeStage deploymentStage = new DeploymentCompositeStage(resourceEnvironmentModelProvider,
+                allocationModelProvider, systemModelProvider, rac);
         final UndeploymentCompositeStage undeploymentStage = new UndeploymentCompositeStage(
                 resourceEnvironmentModelProvider, allocationModelProvider, systemModelProvider, rac);
 


### PR DESCRIPTION
Minor changes. Mainly added missing parameters to example properties file. Relocated configuration for deployment filter outside the filter.